### PR TITLE
Update gpc.json to match current specifications & bugfix for file path not in main branch

### DIFF
--- a/public/.well-known/gpc.json
+++ b/public/.well-known/gpc.json
@@ -1,4 +1,4 @@
 {
   "gpc": true,
-  "version": 1
+  "lastUpdate": "2021-05-13"
 }

--- a/public/client.js
+++ b/public/client.js
@@ -13,7 +13,7 @@ document.addEventListener('readystatechange', (event) => {
     }
 })
 
-fetch("/.well-known/GPC")
+fetch("/.well-known/gpc.json")
   .then(response => response.json())
   .then(json => {
     const wellKnownWrapper = document.getElementById('well-known-code')


### PR DESCRIPTION
Since this [commit](https://github.com/globalprivacycontrol/gpc-spec/commit/6ff08fe4c128f7eb3bcf20daca489b1a833cc747) the `version` member was replaced by the `lastUpdate` member. 

I choose the date of the commit as the `lastUpdate` value.


While testing I noticed the main branch also had a file path which was broken.  On the live site it looks to be fixed already.

https://global-privacy-control.glitch.me/client.js